### PR TITLE
mike/remove_v3_json

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for perl distribution JSON-Validator
 
+2.18_1 2019-02-04
+ - Relax the rules around what is a number for coercion. 
+
 2.18 2018-11-15T16:04:18+0900
  - Add EXPERIMETNAL support for data:// without a package
 

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -26,7 +26,7 @@ use constant VALIDATE_HOSTNAME => eval 'require Data::Validate::Domain;1';
 use constant VALIDATE_IP       => eval 'require Data::Validate::IP;1';
 
 our $ERR;    # ugly hack to improve validation errors
-our $VERSION   = '2.18_01';
+our $VERSION   = '2.18_02';
 our @EXPORT_OK = qw(joi validate_json);
 
 my $BUNDLED_CACHE_DIR = path(path(__FILE__)->dirname, qw(Validator cache));

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -13,7 +13,7 @@ use Mojo::JSON;
 use Mojo::Loader;
 use Mojo::URL;
 use Mojo::Util qw(url_unescape sha1_sum);
-use Scalar::Util qw(blessed refaddr);
+use Scalar::Util qw(blessed refaddr looks_like_number);
 use Time::Local ();
 
 use constant CASE_TOLERANT     => File::Spec->case_tolerant;
@@ -26,7 +26,7 @@ use constant VALIDATE_HOSTNAME => eval 'require Data::Validate::Domain;1';
 use constant VALIDATE_IP       => eval 'require Data::Validate::IP;1';
 
 our $ERR;    # ugly hack to improve validation errors
-our $VERSION   = '2.18';
+our $VERSION   = '2.18_01';
 our @EXPORT_OK = qw(joi validate_json);
 
 my $BUNDLED_CACHE_DIR = path(path(__FILE__)->dirname, qw(Validator cache));
@@ -757,7 +757,7 @@ sub _validate_type_number {
     and $value * 0 == 0)
   {
     return E $path, "Expected $expected - got string."
-      if !$self->{coerce}{numbers} or $value !~ /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
+      if !$self->{coerce}{numbers} or !looks_like_number($value);
     $_[1] = 0 + $value;    # coerce input value
   }
 

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -146,6 +146,7 @@ sub _get {
     $p =~ s!~1!/!g;
     $p =~ s/~0/~/g;
     $pos = _path($pos, $p) if $cb;
+    warn ('path'. _path('', $p));
 
     if (ref $data eq 'HASH' and exists $data->{$p}) {
       $data = $data->{$p};
@@ -194,7 +195,6 @@ sub validate {
   my ($self, $data, $schema) = @_;
   $schema ||= $self->schema->data;
   return E '/', 'No validation rules defined.' unless $schema and %$schema;
-
   local $self->{grouped} = 0;
   local $self->{schema}  = Mojo::JSON::Pointer->new($schema);
   local $self->{seen}    = {};
@@ -479,11 +479,12 @@ sub _stack {
 sub _validate {
   my ($self, $data, $path, $schema) = @_;
   my ($seen_addr, $type, @errors);
-
   $schema = $self->_ref_to_schema($schema) if $schema->{'$ref'};
+  #Store the current data object so that later if we need to coerce the value
+  #we can update the value by reference. Binary.com specific
+  $self->{current_object} = $data if ($schema->{type} and $schema->{type} eq 'object');
   $seen_addr = refaddr $schema;
   $seen_addr .= ':' . (ref $data ? refaddr $data : "s:$data") if defined $data;
-
   # Avoid recursion
   if ($self->{seen}{$seen_addr}) {
     $self->_report_schema($path || '/', 'seen', $schema) if REPORT;
@@ -721,6 +722,10 @@ sub _validate_type_boolean {
     (B::svref_2object(\$value)->FLAGS & (B::SVp_IOK | B::SVp_NOK) or $value =~ /^(true|false)$/))
   {
     $_[1] = $value ? Mojo::JSON->true : Mojo::JSON->false;
+    
+    #Alter the original value by reference, Binary.com specific functionality
+    my @key = keys($self->{current_object}->%*) ;
+    $self->{current_object}->{$key[0]} =$_[1];
     return;
   }
 
@@ -757,9 +762,12 @@ sub _validate_type_number {
     and $value * 0 == 0)
   {
     return E $path, "Expected $expected - got string."
-      if !$self->{coerce}{numbers} or !looks_like_number($value);
-    $_[1] = 0 + $value;    # coerce input value
-  }
+      if !$self->{coerce}{numbers} or !looks_like_number($value); #accept anything that looks like a value Binary.com Specific
+
+   #Alter the original value by reference, Binary.com specific functionality
+   my @key = keys($self->{current_object}->%*);
+    $self->{current_object}->{$key[0]} = 0 + $value;
+  } 
 
   if ($schema->{format}) {
     push @errors, $self->_validate_format($value, $path, $schema);
@@ -849,6 +857,9 @@ sub _validate_type_string {
   {
     return E $path, "Expected string - got number." unless $self->{coerce}{strings};
     $_[1] = "$value";    # coerce input value
+    #Alter the original value by reference, Binary.com specific functionality
+    my @key = keys($self->{current_object}->%*);
+    $self->{current_object}->{$key[0]} =  $_[1]; 
   }
   if ($schema->{format}) {
     push @errors, $self->_validate_format($value, $path, $schema);

--- a/t/jv-boolean.t
+++ b/t/jv-boolean.t
@@ -1,17 +1,19 @@
 use lib '.';
 use t::Helper;
+use Test::More;
 
 sub j { Mojo::JSON::decode_json(Mojo::JSON::encode_json($_[0])); }
 
-my $schema = {type => 'object', properties => {nick => {type => 'boolean'}}};
+my $schema = {
+    type       => 'object',
+    properties => {nick => {type => 'boolean'}}};
 
 validate_ok {nick => true}, $schema;
 validate_ok {nick => 1000},   $schema, E('/nick', 'Expected boolean - got number.');
 validate_ok {nick => 0.5},    $schema, E('/nick', 'Expected boolean - got number.');
 validate_ok {nick => 'nick'}, $schema, E('/nick', 'Expected boolean - got string.');
-validate_ok {nick => bless({}, 'BoolTestOk')},   $schema;
-validate_ok {nick => bless({}, 'BoolTestFail')}, $schema,
-  E('/nick', 'Expected boolean - got BoolTestFail.');
+validate_ok {nick => bless({}, 'BoolTestOk')}, $schema;
+validate_ok {nick => bless({}, 'BoolTestFail')}, $schema, E('/nick', 'Expected boolean - got BoolTestFail.');
 
 validate_ok j(Mojo::JSON->false), {type => 'boolean'};
 validate_ok j(Mojo::JSON->true),  {type => 'boolean'};
@@ -21,11 +23,14 @@ validate_ok undef, {properties => {}}, E('/', 'Expected object - got null.');
 t::Helper->validator->coerce(1);
 validate_ok {nick => 1000}, $schema;
 validate_ok {nick => 0.5},  $schema;
+my $bool_to_coerce = {nick => 5};
+validate_ok $bool_to_coerce, $schema;
+isa_ok($bool_to_coerce->{nick}, 'JSON::PP::Boolean', 'Boolean Coerced data updated');
 
 done_testing;
 
 package BoolTestOk;
-use overload '""' => sub {1};
+use overload '""' => sub { 1 };
 
 package BoolTestFail;
-use overload '""' => sub {2};
+use overload '""' => sub { 2 };

--- a/t/jv-number.t
+++ b/t/jv-number.t
@@ -13,7 +13,8 @@ t::Helper->validator->coerce(numbers => 1);
 validate_ok {mynumber => '-0.3'},   $schema;
 validate_ok {mynumber => '0.1e+1'}, $schema;
 validate_ok {mynumber => '2xyz'},   $schema, E('/mynumber', 'Expected number - got string.');
-validate_ok {mynumber => '.1'},     $schema, E('/mynumber', 'Expected number - got string.');
+validate_ok {mynumber => '.1'},     $schema; 
+validate_ok {mynumber => '001'},    $schema; 
 validate_ok {validNumber => 2.01},
   {type => 'object', properties => {validNumber => {type => 'number', multipleOf => 0.01}}};
 

--- a/t/jv-number.t
+++ b/t/jv-number.t
@@ -1,10 +1,14 @@
 use lib '.';
 use t::Helper;
-
+use Test::More;
 my $schema = {
-  type       => 'object',
-  properties => {mynumber => {type => 'number', minimum => -0.5, maximum => 2.7}}
-};
+    type       => 'object',
+    properties => {
+        mynumber => {
+            type    => 'number',
+            minimum => -0.5,
+            maximum => 2.7
+        }}};
 
 validate_ok {mynumber => 1}, $schema;
 validate_ok {mynumber => '2'}, $schema, E('/mynumber', 'Expected number - got string.');
@@ -13,9 +17,39 @@ t::Helper->validator->coerce(numbers => 1);
 validate_ok {mynumber => '-0.3'},   $schema;
 validate_ok {mynumber => '0.1e+1'}, $schema;
 validate_ok {mynumber => '2xyz'},   $schema, E('/mynumber', 'Expected number - got string.');
-validate_ok {mynumber => '.1'},     $schema; 
-validate_ok {mynumber => '001'},    $schema; 
+validate_ok {mynumber => '.1'},     $schema;
+validate_ok {mynumber => '001'},    $schema;
 validate_ok {validNumber => 2.01},
-  {type => 'object', properties => {validNumber => {type => 'number', multipleOf => 0.01}}};
+    {
+    type       => 'object',
+    properties => {
+        validNumber => {
+            type       => 'number',
+            multipleOf => 0.01
+        }}};
 
+use JSON::Validator;
+my $validator = JSON::Validator->new;
+$validator->coerce(numbers => 1);
+
+$schema = {
+    type       => 'object',
+    properties => {
+        test => {
+            type       => 'object',
+            properties => {
+                mynumber => {
+                    type    => 'number',
+                    minimum => -0.5,
+                    maximum => 2.7
+                }}}}};
+$validator->schema($schema);
+my $number_to_coerce = {test => {mynumber => '001'}};
+$validator->validate($number_to_coerce);
+#validate_ok $number_to_coerce, $schema;
+is($number_to_coerce->{test}->{mynumber}, '1', 'Number has been coerced');
+
+$number_to_coerce = {test => {mynumber => '.01'}};
+$validator->validate($number_to_coerce);
+is($number_to_coerce->{test}->{mynumber}, '0.01', 'Number has been coerced');
 done_testing;

--- a/t/jv-string.t
+++ b/t/jv-string.t
@@ -2,6 +2,7 @@ use lib '.';
 use t::Helper;
 use Test::More;
 use utf8;
+use Data::Dumper;
 
 my $schema = {
   type       => 'object',
@@ -21,5 +22,13 @@ validate_ok {nick => 'Déjà vu'}, $schema;
 
 t::Helper->validator->coerce(1);
 validate_ok {nick => 1000}, $schema;
-
+# testing that the original value is altered after validation
+# this is a Binary.com specific operation. 
+my $string_to_coerce = {nick => 123};
+validate_ok $string_to_coerce, $schema;
+# In pure Perl it is difficult/impossible to test for a string versus a string containing a number
+# Data::Dumper uses c code for its operation so it can tell the difference. 
+my $result =  Dumper($string_to_coerce);
+my $expected = Dumper({nick =>'123'});
+cmp_ok($result, 'eq', $expected, 'Original value was coerced'); 
 done_testing;

--- a/t/jv-string.t
+++ b/t/jv-string.t
@@ -2,7 +2,7 @@ use lib '.';
 use t::Helper;
 use Test::More;
 use utf8;
-use Data::Dumper;
+use JSON::MaybeXS;
 
 my $schema = {
   type       => 'object',
@@ -28,7 +28,7 @@ my $string_to_coerce = {nick => 123};
 validate_ok $string_to_coerce, $schema;
 # In pure Perl it is difficult/impossible to test for a string versus a string containing a number
 # Data::Dumper uses c code for its operation so it can tell the difference. 
-my $result =  Dumper($string_to_coerce);
-my $expected = Dumper({nick =>'123'});
+my $result =  encode_json($string_to_coerce);
+my $expected = encode_json({nick =>'123'});
 cmp_ok($result, 'eq', $expected, 'Original value was coerced'); 
 done_testing;


### PR DESCRIPTION
Note this is a PR against version 2.18 of JSON::Validator the version we use and not the current CPAN version. 